### PR TITLE
Add `return 0;` for some function with intent of integer out

### DIFF
--- a/solvers/laminarSMOKE/unsteady/BatchReactorHomogeneousConstantPressure.H
+++ b/solvers/laminarSMOKE/unsteady/BatchReactorHomogeneousConstantPressure.H
@@ -362,6 +362,7 @@ void BatchReactorHomogeneousConstantPressure::Equations(double* y, std::vector<d
 
 int BatchReactorHomogeneousConstantPressure::Print(const double t, const OpenSMOKE::OpenSMOKEVectorDouble& y)
 {
+	return 0;
 }
 
 #endif // BatchReactorHomogeneousConstantPressure_H

--- a/solvers/laminarSMOKE/unsteady/BatchReactorHomogeneousConstantPressureVirtualChemistry.H
+++ b/solvers/laminarSMOKE/unsteady/BatchReactorHomogeneousConstantPressureVirtualChemistry.H
@@ -213,6 +213,7 @@ void BatchReactorHomogeneousConstantPressureVirtualChemistry::Equations(double* 
 
 int BatchReactorHomogeneousConstantPressureVirtualChemistry::Print(const double t, const OpenSMOKE::OpenSMOKEVectorDouble& y)
 {
+	return 0;
 }
 
 #endif // BatchReactorHomogeneousConstantPressureVirtualChemistry_H

--- a/solvers/laminarSMOKE/unsteady/BatchReactorHomogeneousConstantVolume.H
+++ b/solvers/laminarSMOKE/unsteady/BatchReactorHomogeneousConstantVolume.H
@@ -206,6 +206,7 @@ void BatchReactorHomogeneousConstantVolume::Equations(double* y, std::vector<dou
 
 int BatchReactorHomogeneousConstantVolume::Print(const double t, const OpenSMOKE::OpenSMOKEVectorDouble& y)
 {
+	return 0;
 }
 
 #endif // BatchReactorHomogeneousConstantVolume_H


### PR DESCRIPTION
### Observation
When I run `laminarBuoyantPimpleSMOKE`, the default ODE solver `OpenSMOKE` can not proceed correctly, the error output is as follow:
![debugOpenSMOKE](https://user-images.githubusercontent.com/23146874/156924798-4d443040-0696-4e08-967c-d023fa7154b1.png)

And that is fixed in this version, with some functions add `return 0;`

Tests are made with `OpenFOAM-5.x` on a Debian 4.19.208-1 (2021-09-29) amd64 server,
